### PR TITLE
[SCNS-1196] ROS2 interface 빌드 속도 개선

### DIFF
--- a/rosidl_cmake/rosidl_cmake/__init__.py
+++ b/rosidl_cmake/rosidl_cmake/__init__.py
@@ -23,6 +23,11 @@ import em
 from rosidl_parser.definition import IdlLocator
 from rosidl_parser.parser import parse_idl_file
 
+# for multiprocessing parse_idl_file
+import pickle
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from multiprocessing import cpu_count
+
 
 def convert_camel_case_to_lower_case_underscore(value):
     # insert an underscore before any upper case letter
@@ -47,10 +52,63 @@ def get_newest_modification_time(target_dependencies):
             newest_timestamp = ts
     return newest_timestamp
 
+def _process_one_idl(args_pack):
+    """process one idl file, it will be multiprocessed."""
+    (idl_tuple, args, mapping, keep_case,
+     additional_context, latest_target_timestamp,
+     template_basepath, post_process_callback) = args_pack
+
+    idl_parts = idl_tuple.rsplit(':', 1)
+    assert len(idl_parts) == 2
+    locator = IdlLocator(*idl_parts)
+    idl_rel_path = pathlib.Path(idl_parts[1])
+    idl_stem = idl_rel_path.stem
+    if not keep_case:
+        idl_stem = convert_camel_case_to_lower_case_underscore(idl_stem)
+
+    try:
+        idl_file = parse_idl_file(locator)
+        generated_files = []
+
+        for template_file, generated_filename in mapping.items():
+            generated_file = os.path.join(
+                args['output_dir'], str(idl_rel_path.parent),
+                generated_filename % idl_stem
+            )
+            #os.makedirs(os.path.dirname(generated_file), exist_ok=True)
+
+            generated_files.append(generated_file)
+
+            data = {
+                'package_name': args['package_name'],
+                'interface_path': idl_rel_path,
+                'content': idl_file.content,
+            }
+            if additional_context is not None:
+                data.update(additional_context)
+
+            expand_template(
+                os.path.basename(template_file),
+                data,
+                generated_file,
+                minimum_timestamp=latest_target_timestamp,
+                template_basepath=template_basepath,
+                post_process_callback=post_process_callback
+            )
+
+        return generated_files
+
+    except Exception as e:
+        print(
+            'Error processing idl file: ' + str(locator.get_absolute_path()),
+            file=sys.stderr
+        )
+        raise(e)
+
 
 def generate_files(
     generator_arguments_file, mapping, additional_context=None,
-    keep_case=False, post_process_callback=None
+    keep_case=False, post_process_callback=None, jobs=None
 ):
     args = read_generator_arguments(generator_arguments_file)
 
@@ -60,42 +118,62 @@ def generate_files(
             'Could not find template: ' + template_filename
 
     latest_target_timestamp = get_newest_modification_time(args['target_dependencies'])
-    generated_files = []
+    generated_files_all = []
 
-    for idl_tuple in args.get('idl_tuples', []):
-        idl_parts = idl_tuple.rsplit(':', 1)
-        assert len(idl_parts) == 2
-        locator = IdlLocator(*idl_parts)
-        idl_rel_path = pathlib.Path(idl_parts[1])
-        idl_stem = idl_rel_path.stem
-        if not keep_case:
-            idl_stem = convert_camel_case_to_lower_case_underscore(idl_stem)
+    idl_tuples = list(args.get('idl_tuples', []))
+    if not idl_tuples:
+        return generated_files_all
+
+    use_pool = True
+    if post_process_callback is not None:
         try:
-            idl_file = parse_idl_file(locator)
-            for template_file, generated_filename in mapping.items():
-                generated_file = os.path.join(
-                    args['output_dir'], str(idl_rel_path.parent),
-                    generated_filename % idl_stem)
-                generated_files.append(generated_file)
-                data = {
-                    'package_name': args['package_name'],
-                    'interface_path': idl_rel_path,
-                    'content': idl_file.content,
-                }
-                if additional_context is not None:
-                    data.update(additional_context)
-                expand_template(
-                    os.path.basename(template_file), data,
-                    generated_file, minimum_timestamp=latest_target_timestamp,
-                    template_basepath=template_basepath,
-                    post_process_callback=post_process_callback)
-        except Exception as e:
-            print(
-                'Error processing idl file: ' +
-                str(locator.get_absolute_path()), file=sys.stderr)
-            raise(e)
+            pickle.dumps(post_process_callback)
+        except Exception:
+            use_pool = False
 
-    return generated_files
+    if jobs is None or jobs <= 0:
+        jobs = min(cpu_count(), max(1, len(idl_tuples)))
+
+    task_args = [
+        (idl_tuple, args, mapping, keep_case, additional_context,
+         latest_target_timestamp, template_basepath, post_process_callback)
+        for idl_tuple in idl_tuples
+    ]
+
+    def _run_in_executor(executor_cls, max_workers, tasks):
+        results = []
+        with executor_cls(max_workers=max_workers) as ex:
+            futures = [ex.submit(_process_one_idl, a) for a in tasks]
+            for fut in as_completed(futures):
+                res = fut.result()
+                if res:
+                    results.extend(res)
+        return results
+
+    if use_pool and jobs > 1:
+        # Parallel
+        try:
+            generated_files_all.extend(
+                _run_in_executor(ProcessPoolExecutor, jobs, task_args)
+            )
+        except Exception as e:
+            # fallback to ThreadPool
+            print(
+                f"[rosidl_generator] ProcessPoolExecutor failed ({type(e).__name__}: {e}). "
+                "Falling back to ThreadPoolExecutor.",
+                file=sys.stderr
+            )
+            generated_files_all.extend(
+                _run_in_executor(ThreadPoolExecutor, jobs, task_args)
+            )
+    else:
+        # Sequential
+        for a in task_args:
+            result = _process_one_idl(a)
+            if result:
+                generated_files_all.extend(result)
+
+    return generated_files_all
 
 
 template_prefix_path = []

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -143,6 +143,24 @@ add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 
+if(ROSIDL_ENABLE_PCH AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
+  target_precompile_headers(${rosidl_generate_interfaces_TARGET}${_target_suffix} INTERFACE
+    # idl__functions.c.em
+    $<$<COMPILE_LANGUAGE:C>:"assert.h">
+    $<$<COMPILE_LANGUAGE:C>:"stdbool.h">
+    $<$<COMPILE_LANGUAGE:C>:"stdlib.h">
+    $<$<COMPILE_LANGUAGE:C>:"string.h">
+    # idl__functions.h.em
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_runtime_c/visibility_control.h">
+    # idl__struct.h.em
+    $<$<COMPILE_LANGUAGE:C>:"stddef.h">
+    $<$<COMPILE_LANGUAGE:C>:"stdint.h">
+    # idl_type_support.h.em
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_typesupport_interface/macros.h">
+  )
+endif()
+
+
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   if(NOT _generated_headers STREQUAL "")
     install(

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -130,6 +130,25 @@ target_link_libraries(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix} INTERFACE
   ${rosidl_runtime_cpp_TARGETS})
 
+if(ROSIDL_ENABLE_PCH AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
+  target_precompile_headers(${rosidl_generate_interfaces_TARGET}${_target_suffix} INTERFACE
+    # idl__builder.hpp.em
+    $<$<COMPILE_LANGUAGE:CXX>:"utility">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_runtime_cpp/message_initialization.hpp">
+    # idl__struct.hpp.em
+    $<$<COMPILE_LANGUAGE:CXX>:"algorithm">
+    $<$<COMPILE_LANGUAGE:CXX>:"array">
+    $<$<COMPILE_LANGUAGE:CXX>:"memory">
+    $<$<COMPILE_LANGUAGE:CXX>:"string">
+    $<$<COMPILE_LANGUAGE:CXX>:"vector">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_runtime_cpp/bounded_vector.hpp">
+    # idl__traits.hpp.em
+    $<$<COMPILE_LANGUAGE:CXX>:"stdint.h">
+    $<$<COMPILE_LANGUAGE:CXX>:"type_traits">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_runtime_cpp/traits.hpp">
+  )
+endif()
+
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   if(NOT _generated_headers STREQUAL "")
     install(

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -132,6 +132,23 @@ add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 
+if(ROSIDL_ENABLE_PCH AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
+  target_precompile_headers(${rosidl_generate_interfaces_TARGET}${_target_suffix} PRIVATE
+    # msg__rosidl_typesupport_introspection_c.h.em
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_runtime_c/message_type_support_struct.h">
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_typesupport_interface/macros.h">
+    # msg__type_support.c.em
+    $<$<COMPILE_LANGUAGE:C>:"stddef.h">
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_typesupport_introspection_c/field_types.h">
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_typesupport_introspection_c/identifier.h">
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_typesupport_introspection_c/message_introspection.h">
+    # srv__rosidl_typesupport_introspection_c.h.em
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_runtime_c/service_type_support_struct.h">
+    # srv__type_support.c.em
+    $<$<COMPILE_LANGUAGE:C>:"rosidl_typesupport_introspection_c/service_introspection.h">
+  )
+endif()
+
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   if(NOT _generated_header_files STREQUAL "")
     install(

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -125,6 +125,34 @@ add_dependencies(
   ${rosidl_generate_interfaces_TARGET}__cpp
 )
 
+if(ROSIDL_ENABLE_PCH AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
+  target_precompile_headers(${rosidl_generate_interfaces_TARGET}${_target_suffix} PRIVATE
+    # msg__rosidl_typesupport_introspection_cpp.hpp.em
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_runtime_c/message_type_support_struct.h">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_interface/macros.h">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_introspection_cpp/visibility_control.h">
+    # msg__type_support.cpp.em
+    $<$<COMPILE_LANGUAGE:CXX>:"array">
+    $<$<COMPILE_LANGUAGE:CXX>:"cstddef">
+    $<$<COMPILE_LANGUAGE:CXX>:"string">
+    $<$<COMPILE_LANGUAGE:CXX>:"vector">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_runtime_c/message_type_support_struct.h">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_cpp/message_type_support.hpp">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_interface/macros.h">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_introspection_cpp/field_types.hpp">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_introspection_cpp/identifier.hpp">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_introspection_cpp/message_introspection.hpp">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_introspection_cpp/visibility_control.h">
+    # srv__rosidl_typesupport_introspection_cpp.hpp.em
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_runtime_c/service_type_support_struct.h">
+    # srv__type_support.cpp.em
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_cpp/service_type_support.hpp">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_introspection_cpp/service_introspection.hpp">
+    $<$<COMPILE_LANGUAGE:CXX>:"rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp">
+  )
+endif()
+
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   if(NOT _generated_header_files STREQUAL "")
     install(


### PR DESCRIPTION
- rosidl_parser에 multiprocessing 적용
  - ROS2 interface 빌드에서 가장 bottleneck은 rosidl_parser로 각 작업이 atomic함에도 불구하고 순차적으로 빌드를 실행하고 있었음
  - interface 빌드 과정에서 가장 빈번하게 사용되는 parse_idl_file를 병렬 처리
  - generate_files, generate_py에서 core 개수 만큼의 job으로 쪼개 ProcessPoolExecutor로 처리함
- 반복되어 빌드되는 header에 PCH(Precompile Header) 적용
  - msg/srv header에 항상 포함되는 vector, array 등 반복되는 header를 precompile하여 사용